### PR TITLE
Sh #25 add summary text home

### DIFF
--- a/NavPages/Home.js
+++ b/NavPages/Home.js
@@ -1,11 +1,17 @@
 import React from 'react';
-import { DText, View, StyleSheet, Image } from 'react-native';
+import { View, StyleSheet, Text } from 'react-native';
 import Header from '../shared/Header';
+import styles from '../StyleSheet/SummaryStyle';
 
 
 function Home() {
   return (
-    <Header />
+    <>
+      <Header />
+      <View>
+        <Text style={styles.summaryText}>The Whitman County Historical Society Lost Apple Project seeks to identify and preserve heritage apple trees and orchards in the Inland Empire. </Text>
+      </View>
+    </>
   );
 };
 export default Home;

--- a/StyleSheet/HeaderStyle.js
+++ b/StyleSheet/HeaderStyle.js
@@ -26,8 +26,5 @@ export default StyleSheet.create({
         alignSelf: 'center',
         fontWeight: 'bold',
     }
-    ,
-    summaryText: {
 
-    }
 });

--- a/StyleSheet/SummaryStyle.js
+++ b/StyleSheet/SummaryStyle.js
@@ -1,0 +1,12 @@
+import { StyleSheet } from "react-native";
+
+export default StyleSheet.create({
+    summaryText: {
+        backgroundColor: 'maroon',
+        color: 'white',
+        margin: 10,
+        padding: 15,
+        textAlign: 'center',
+        fontSize: 18,
+    }
+});

--- a/shared/Header.js
+++ b/shared/Header.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, View, Image } from 'react-native';
-import styles from './header.component.style';
+import styles from '../StyleSheet/HeaderStyle';
 
 export default function Header() {
     return (


### PR DESCRIPTION
Closes #25
Adding summary text to Home page. 
Also moved some style files to correct StyleSheet folder.

What you should see:
![image](https://user-images.githubusercontent.com/24535467/138752410-750ea360-b084-413c-9e7f-4b01ad96465d.png)
