### PR TITLE
apply initial css styles to appledetails page

### DIFF
--- a/NavPages/AppleDetails.js
+++ b/NavPages/AppleDetails.js
@@ -1,16 +1,26 @@
 import React from 'react';
-import {Text, View} from 'react-native';
+import {Text, View, Image} from 'react-native';
 import appleList from './Apples';
+import Header from '../shared/Header';
+import styles from '../StyleSheet/AppleDetailsStyle';
 
 const AppleDetails = ({navigation, route}) => {
   apDeets = route.params.id;
   //console.log('Params: ' + JSON.stringify(apDeets));
 
   return (
-    <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
-      <Text>{apDeets.name}</Text>
-      <Text>Found: {apDeets.found ? apDeets.found : '???'}</Text>
-      <Text>{apDeets.location}</Text>
+    <View style={{flex: 1, alignItems: 'center'}}>
+      <Header />
+      <View style={styles.title} >
+        <Text style={styles.titleText}>{apDeets.name}</Text>
+      </View>
+      <Image
+          style={styles.applePlaceholder}
+          source={require('../Images/apple-3155.png')}
+        />
+      <Text style={styles.locText}>Found: {apDeets.found ? apDeets.found : '???'}</Text>
+      <Text style={styles.locText}>{apDeets.location}</Text>
+      <Text style={styles.descText}>Description of the apple</Text>
 
       {/* ADD FUTURE APPLE IMAGE, APPLE DESC, POSSIBLE EMBEDDED MAP FOR LOCATION?  */}
     </View>

--- a/StyleSheet/AppleDetailsStyle.js
+++ b/StyleSheet/AppleDetailsStyle.js
@@ -1,0 +1,68 @@
+import {StyleSheet, StatusBar} from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    /* marginTop: StatusBar.currentHeight || 0, */
+  },
+  item: {
+    flexDirection: 'row',
+    backgroundColor: 'crimson',
+    padding: 10,
+    marginVertical: 8,
+    marginHorizontal: 16,
+  },
+
+  title: {
+    /* flex: 1, */
+    padding: 10,
+    marginVertical: 8,
+    marginHorizontal: 8,
+        /* flexDirection: 'row', */
+    backgroundColor: 'crimson',
+    /* alignItems: 'center', */
+    alignSelf: 'stretch',
+  },
+
+  titleText: {
+    fontSize: 20,
+    color: 'white',
+    fontWeight: 'bold',
+    alignSelf: 'center',
+
+  },
+
+  locText: {
+    textAlign: 'center',
+    fontSize: 15,
+    padding: 1,
+    fontWeight: 'bold',
+    color: 'black',
+  },
+
+  applePlaceholder: {
+    width: 120,
+    height: 120,
+    margin: 10,
+    backgroundColor: 'green',
+    /* alignSelf: 'center', */
+    borderWidth: 2,
+    borderColor: 'black',
+    borderRadius: 10,
+    flexDirection: 'column',
+  },
+
+  descText: {
+    backgroundColor: 'antiquewhite',
+    color: 'black',
+    alignItems: 'center',
+    alignSelf: 'center',
+    textAlign: 'center',
+    fontSize: 16,
+    marginTop: 5,
+    marginBottom: 5,
+    padding: 15,
+    width: '80%',
+  },
+
+});


### PR DESCRIPTION
Resolves Issue #60.

Apply display stylings to currently displaying firebase information on the AppleDetails page (Apple name, found status, location). Also includes the Header component for app consistency.

Also added a Description placeholder and Image placeholder, should those elements be eventually added.

Have not included a map embed yet--that will be a separate ticket.

Tested on: Win10 laptop, Chrome v92.

Verification steps:

1. Load app and pull up in emulator.
2. Navigate to the Apples tab.
3. Select any apple from the list.
4. View current firebase information displayed, as well as included header and placeholder image/desc elements.

Sample of what you should see:
![image](https://user-images.githubusercontent.com/49133101/141874420-f59e4eec-35e5-4adb-a3b4-074992a0f17b.png)

  